### PR TITLE
Fix undefined parameter in api.sprint.setProperty()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ api.backlog = {};
  *   Array of issue ids, eg ['PR-1'].
  */
 api.backlog.moveIssuesToBacklog = issues =>
-  sendRequestWithPayload('backlog/issue', {issues: issues})
+  sendRequestWithPayload('backlog/issue', {issues: issues});
 
 api.board = {};
 
@@ -134,7 +134,7 @@ api.sprint.getPropertiesKeys = (sprintId, params) =>
 api.sprint.deleteProperty = (sprintId, propertyKey) =>
   sendDeleteRequest(`sprint/${sprintId}/properties/${propertyKey}`);
 
-api.sprint.setProperty = (sprintId, value) =>
+api.sprint.setProperty = (sprintId, propertyKey, value) =>
   sendRequestWithPayload(`sprint/${sprintId}/properties/${propertyKey}`, { value }, 'PUT');
 
 api.sprint.getProperty = (sprintId, propertyKey, params) =>


### PR DESCRIPTION
The `${propertyKey}` variable used in `api.sprint.setProperty()` was undefined. It should have been a parameter to the method.